### PR TITLE
virtqueue: use size_t

### DIFF
--- a/libsel4camkes/include/camkes/error.h
+++ b/libsel4camkes/include/camkes/error.h
@@ -227,7 +227,6 @@ camkes_error_action_t camkes_error(camkes_error_t *e) COLD;
  *    statement).
  */
 #define ERR(handler, edata, action) ({ \
-            COLD_PATH(); \
             camkes_error_t _e = edata; \
             _e.filename = __FILE__; \
             _e.lineno = __LINE__; \

--- a/libsel4camkes/include/camkes/error.h
+++ b/libsel4camkes/include/camkes/error.h
@@ -231,20 +231,11 @@ camkes_error_action_t camkes_error(camkes_error_t *e) COLD;
             _e.filename = __FILE__; \
             _e.lineno = __LINE__; \
             switch (handler(&_e)) { \
-                case CEA_DISCARD: \
-                    action; \
-                    UNREACHABLE(); \
-                case CEA_IGNORE: \
-                    break; \
-                case CEA_HALT: \
-                    halt(); \
-                    /* If we return we'll just fall through. */ \
-                case CEA_ABORT: \
-                    abort(); \
-                    /* In case we return */ \
-                    while(1); \
-                default: \
-                    UNREACHABLE(); \
+                case CEA_DISCARD: action; UNREACHABLE(); \
+                case CEA_IGNORE: break; \
+                case CEA_ABORT: abort(); UNREACHABLE(); \
+                case CEA_HALT: /* fall though */ \
+                default: halt(); UNREACHABLE(); \
             } \
         })
 


### PR DESCRIPTION
Use size_t consistently for buffer length in the API.